### PR TITLE
correção do nome dos estados

### DIFF
--- a/Oncomap/frontend/src/components/MapaPage/mapa.tsx
+++ b/Oncomap/frontend/src/components/MapaPage/mapa.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { MapContainer, GeoJSON } from 'react-leaflet';
 import type { Feature, FeatureCollection, Geometry } from 'geojson';
@@ -6,6 +5,17 @@ import L, { type Layer } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import '../../style/MapaPage.css';
 import { regioesGeoJson } from '../../data/regioes';
+
+// --- NOVO: Mapeamento de Códigos IBGE para Nomes dos Estados ---
+const CODIGO_PARA_ESTADO: Record<string, string> = {
+  '11': 'Rondônia', '12': 'Acre', '13': 'Amazonas', '14': 'Roraima',
+  '15': 'Pará', '16': 'Amapá', '17': 'Tocantins',
+  '21': 'Maranhão', '22': 'Piauí', '23': 'Ceará', '24': 'Rio Grande do Norte',
+  '25': 'Paraíba', '26': 'Pernambuco', '27': 'Alagoas', '28': 'Sergipe', '29': 'Bahia',
+  '31': 'Minas Gerais', '32': 'Espírito Santo', '33': 'Rio de Janeiro', '35': 'São Paulo',
+  '41': 'Paraná', '42': 'Santa Catarina', '43': 'Rio Grande do Sul',
+  '50': 'Mato Grosso do Sul', '51': 'Mato Grosso', '52': 'Goiás', '53': 'Distrito Federal'
+};
 
 interface GeoProperties {
   codarea?: string;
@@ -132,9 +142,16 @@ const MapaInterativo: React.FC<MapProps> = ({
     return { fillColor, weight: 1, color: 'white', fillOpacity: 1 };
   };
 
+  // --- FUNÇÃO CORRIGIDA ---
   const onEachStateFeature = (feature: GeoFeature, layer: Layer) => {
     const regiaoDoEstado = feature.properties.regiao || 'Região';
-    const nomeDoEstado = feature.properties.nome || feature.properties.name || 'Estado';
+    
+    // Tenta pegar o nome pelo código IBGE usando a nossa lista
+    const codigo = feature.properties.codarea;
+    const nomeDoEstado = (codigo && CODIGO_PARA_ESTADO[codigo]) 
+      || feature.properties.nome 
+      || feature.properties.name 
+      || 'Estado';
 
     const tooltipContent = selectedRegion
       ? nomeDoEstado 


### PR DESCRIPTION
📌 Descrição
Esta PR corrige um bug na visualização do mapa interativo onde o tooltip dos estados exibia o texto genérico "Estado" em vez do nome da Unidade Federativa. Foi implementado um dicionário de mapeamento (CODIGO_PARA_ESTADO) no frontend para converter os códigos IBGE (codarea) diretamente para os nomes dos estados, garantindo a exibição correta independente das propriedades do GeoJSON.

🔗 Issue Relacionada
Closes # [109]

✅ Tipo de Mudança
Selecione o tipo de mudança que esta PR introduz. Marque com um 'x' dentro dos colchetes, como [x].

[x] Correção de bug (Uma mudança que corrige um problema)

[ ] Nova funcionalidade (Uma mudança que adiciona novas funcionalidades)

[ ] Refatoração (Uma mudança no código que não corrige um bug nem adiciona funcionalidade)

[ ] Documentação (Uma mudança que afeta apenas a documentação)

🔍 Checklist
Verifique os itens abaixo antes de finalizar a PR. Marque com um 'x' dentro dos colchetes, como [x].

[ ] Testes criados/atualizados

[ ] Documentação atualizada (se necessário)

[x] PR revisada e pronta para merge

📝 Notas Adicionais (Opcional)
Para testar a correção:

Inicie a aplicação (docker-compose up).

Acesse a rota /mapa.

Passe o mouse sobre qualquer estado no mapa.

O tooltip deve exibir o nome correto (ex: "Mato Grosso", "Bahia") em vez de "Estado".
