### PR TITLE
Update runner to self-hosted for monthly pipeline

### DIFF
--- a/.github/workflows/coletor_mensal.yml
+++ b/.github/workflows/coletor_mensal.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-monthly-pipeline:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     
     # Define um tempo limite para evitar que o processo fique travado para sempre pagando horas
     timeout-minutes: 60 


### PR DESCRIPTION
## 📌 Descrição

Este PR corrige o erro crítico **403 Forbidden** que ocorria durante a execução do pipeline de coleta de dados no GitHub Actions.

O problema foi identificado como um **bloqueio geográfico (Geo-blocking)** ou de IP por parte da API do *Querido Diário*, que rejeita requisições originadas dos servidores do GitHub (localizados nos EUA).

Para resolver isso, implementamos uma estratégia de **Self-Hosted Runner**, movendo a execução do script para uma máquina localizada no Brasil, além de melhorias nos cabeçalhos das requisições HTTP.

---

## 🔗 Issue Relacionada

Closes # [Número da Issue, se houver]

---

## ✅ Tipo de Mudança

* [x] **Correção de bug** (Fix do erro 403 e variáveis de ambiente não carregadas)
* [ ] **Nova funcionalidade**
* [x] **DevOps / Infraestrutura** (Alteração de runner e configuração de workflow)
* [ ] **Refatoração**

---

## 🛠️ Detalhes Técnicos

### 1. Alteração do Runner (`.github/workflows/*.yml`)
* **De:** `runs-on: ubuntu-latest` (Cloud GitHub / IP EUA)
* **Para:** `runs-on: self-hosted` (Máquina Local / IP Brasil)
* **Motivo:** Garantir que o IP de origem da requisição seja brasileiro para passar pelo firewall da API externa.

### 2. Injeção de Variáveis de Ambiente
* Correção na passagem de segredos. O `dotenv` não funciona no ambiente de CI porque o arquivo `.env` é ignorado pelo git.
* As variáveis `DATABASE_URL` e `GEMINI_API_KEYS` agora são injetadas explicitamente via `env:` no YAML, lendo dos **GitHub Secrets**.

### 3. Identificação do Cliente HTTP (`axios`)
* Adicionado o header `User-Agent` nas requisições do `axios`.
* **Motivo:** Evitar bloqueios de segurança que rejeitam requisições sem identificação de navegador (comportamento anti-bot padrão).

---

## 🔍 Checklist de Validação

* [x] O Runner Self-Hosted está instalado, configurado e com status "Active" no repositório.
* [x] O workflow foi disparado manualmente (`workflow_dispatch`) e executou sem erro 403.
* [x] As variáveis de ambiente (Secrets) foram lidas corretamente pelo script.
* [x] O banco de dados recebeu os dados coletados durante o teste.

---

### 📝 Notas para o Revisor / Operação

⚠️ **Atenção: Dependência de Infraestrutura**

Para que este pipeline funcione (tanto no agendamento mensal quanto manual), a máquina configurada como **Self-Hosted Runner** deve estar:
1.  **Ligada** e conectada à internet.
2.  Com o serviço do runner rodando (`sudo ./svc.sh status`).

Caso a máquina esteja offline no momento do Cron (`0 5 1 * *`), o job falhará ou ficará em fila até que a máquina fique online.