### PR TITLE
feat: menção do querido diario na tabela de diarios oficiais

### DIFF
--- a/Oncomap/frontend/src/components/MapaPage/TabelaInfo.tsx
+++ b/Oncomap/frontend/src/components/MapaPage/TabelaInfo.tsx
@@ -162,6 +162,9 @@ const API_BASE_URL = `${import.meta.env.VITE_API_URL || "https://oncomap-backend
           </div>
 
           <h4 className="secao-titulo">Fontes (Diários Oficiais)</h4>
+          <div className="mencao-querido-diario">
+            <p>Dados Extraidos <a href="https://queridodiario.ok.org.br/" target="_blank">Querido Diário</a></p>
+          </div>
           <ul className="lista-links-scroll">
             {detalhesMunicipio.recent_mentions.length > 0 ? (
                 detalhesMunicipio.recent_mentions.map((mencao, idx) => (

--- a/Oncomap/frontend/src/style/Tabelainfo.css
+++ b/Oncomap/frontend/src/style/Tabelainfo.css
@@ -380,6 +380,21 @@
   list-style: none;
 }
 
+.mencao-querido-diario {
+  font-size: 0.75rem;
+  color: #ddd;
+  opacity: 0.8;           
+  margin-bottom: 15px;     
+  font-weight: 300;        
+  letter-spacing: 0.5px;   
+}
+
+.mencao-querido-diario a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
 .lista-links-item {
   padding: 12px 15px;
   border-bottom: 1px dashed rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
# UI: Melhoria visual na indicação da fonte (Querido Diário)

## 🖼️ O que mudou?
Fizemos um ajuste visual na parte que mostra de onde os dados vieram. Agora, a frase "Dados Extraídos do Querido Diário" tem um destaque melhor e mais organizado na lista.

O objetivo é deixar claro para o usuário, logo de cara, que aquela informação é oficial e vem de uma fonte confiável, separando visualmente o que é a "Fonte" do que é o "Dado" (datas e links).

## ✨ Detalhes da mudança
* **Destaque na Origem:** Adicionamos uma etiqueta "FONTE:" para facilitar a leitura rápida.
* **Visual mais Limpo:** O texto explicativo ficou mais suave e leve, tirando a sensação de "peso" da tela.
* **Organização:** Melhoramos o alinhamento para combinar com o restante do design do OncoMap.


## ✅ Checklist
- [x] O visual ficou mais agradável e fácil de ler.
- [x] As cores combinam com a identidade verde do projeto.
- [x] A informação da fonte está clara e visível.

---